### PR TITLE
add support common options with moreOpts key

### DIFF
--- a/app/middleware/graphql.js
+++ b/app/middleware/graphql.js
@@ -5,6 +5,7 @@ const { graphqlKoa, graphiqlKoa } = require('apollo-server-koa');
 module.exports = (_, app) => {
   const options = app.config.graphql;
   const graphQLRouter = options.router;
+  const moreOpts = options.moreOpts || {};
   let graphiql = true;
 
   if (options.graphiql === false) {
@@ -28,6 +29,7 @@ module.exports = (_, app) => {
       return graphqlKoa({
         schema: app.schema,
         context: ctx,
+        ...moreOpts
       })(ctx);
     }
     await next();


### PR DESCRIPTION
由于需要格式化返回错误信息，新增了通用配置项

如:
```
  config.graphql = {
    router: '/graphql',
    moreOpts: {
      formatError: error => ({
        message: 'interal error',
        locations: error.locations,
        path: error.path,
      }),
    },
  };
```



