### PR TITLE
feat: Support default empty schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ exports.graphql = {
   agent: false,
   // 是否加载开发者工具 graphiql, 默认开启。路由同 router 字段。使用浏览器打开该可见。
   graphiql: true,
+  //是否设置默认的Query和Mutation, 默认关闭
+  defaultEmptySchema:true,
   // graphQL 路由前的拦截器
   onPreGraphQL: function* (ctx) {},
   // 开发工具 graphiQL 路由前的拦截器，建议用于做权限操作(如只提供开发者使用)

--- a/lib/load_schema.js
+++ b/lib/load_schema.js
@@ -19,7 +19,14 @@ module.exports = app => {
   const resolverFactories = [];
   const directiveMap = {};
   const schemaDirectivesProps = {};
-
+  const { defaultEmptySchema = false } = app.config.graphql;
+  const defaultSchema = `
+    type Query 
+    type Mutation 
+  `;
+  if (defaultEmptySchema) {
+    schemas.push(defaultSchema);
+  }
   types.forEach(type => {
     // Load schema
     const schemaFile = path.join(basePath, type, 'schema.graphql');

--- a/test/app/middleware/graphql.test.js
+++ b/test/app/middleware/graphql.test.js
@@ -62,3 +62,45 @@ describe('test/app/middleware.test.js', () => {
     });
   });
 });
+
+describe('test/app/middleware.test.js', () => {
+  let app;
+
+  before(() => {
+    app = mm.app({
+      baseDir: 'apps/default-schema-app',
+    });
+    return app.ready();
+  });
+
+  after(mm.restore);
+  it('should add user', async () => {
+    const query = `
+    mutation addUser{
+      addUser(name:"小李",password:"123456"){
+        id
+        name
+        password
+      }
+    }
+    `;
+    app.mockCsrf();
+
+    await app.httpRequest()
+      .post('/graphql')
+      .send({
+        query,
+      })
+      .expect(200);
+
+    const res = await app.httpRequest()
+      .get('/graphql?query=query+getUser($id:Int){user(id:$id){id\nname\npassword}}&variables={"id":1}')
+      .expect(200);
+    assert.deepEqual(res.body.data.user, {
+      id: 1,
+      name: '小李',
+      password: '123456',
+    });
+
+  });
+});

--- a/test/fixtures/apps/default-schema-app/app/graphql/user/resolver.js
+++ b/test/fixtures/apps/default-schema-app/app/graphql/user/resolver.js
@@ -1,0 +1,24 @@
+'use strict';
+const Users = [];
+module.exports = {
+  Query: {
+    user(root, { id }) {
+      // eslint-disable-next-line eqeqeq
+      const user = Users.find(user => user.id == id);
+      return user;
+    },
+  },
+  Mutation: {
+    addUser(root, { password, name }) {
+      const id = Users.length + 1;
+      const user = {
+        id,
+        password,
+        name,
+      };
+
+      Users.push(user);
+      return user;
+    },
+  },
+};

--- a/test/fixtures/apps/default-schema-app/app/graphql/user/schema.graphql
+++ b/test/fixtures/apps/default-schema-app/app/graphql/user/schema.graphql
@@ -1,0 +1,11 @@
+type User {
+  id: String!
+  password: String!
+  name: String!
+}
+extend type Query {
+  user(id: Int): User
+}
+extend type Mutation {
+  addUser(password: String, name: String): User
+}

--- a/test/fixtures/apps/default-schema-app/config/config.unittest.js
+++ b/test/fixtures/apps/default-schema-app/config/config.unittest.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.keys = 'plugin-graphql';
+exports.middleware = [ 'graphql' ];
+exports.graphql = {
+  graphiql: true,
+  defaultEmptySchema: true,
+};

--- a/test/fixtures/apps/default-schema-app/package.json
+++ b/test/fixtures/apps/default-schema-app/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "grapgql-app"
+  "name": "default-schema-app"
 }

--- a/test/fixtures/apps/default-schema-app/package.json
+++ b/test/fixtures/apps/default-schema-app/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "grapgql-app"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
支持添加默认schema选项  
```js
exports.graphql = {
  defaultEmptySchema:true,
}
```
这样可以不用定义Query和Mutation,直接使用extend继承
```graphql
#app/graphql/user/schema.graphql
extend type Query {
  user(id: ID!): User
}
extend type Mutation {
  addUser(input: AddUser): User
}
input AddUser {
  name: String
  age: Int
}
type User {
  id: ID!
  name: String
  age: Int
}
```
未设置默认 Query 之前,假如有 user,tag 两个表，需要建四个文件夹,这样导致 mutation,query 包含了所有的一级查询,增加,更新,删除
```
app
└── graphql
    ├── mutation
    │   └── schema.graphql
    ├── query
    │   └── schema.graphql
    ├── tag
    │   ├── resolver.js
    │   └── schema.graphql
    └── user
        ├── resolver.js
        └── schema.graphql
```
有了默认 Query 后,只需要建两个文件夹

```
app
└── graphql
    ├── tag
    │   ├── resolver.js
    │   └── schema.graphql
    └── user
        ├── resolver.js
        └── schema.graphql
```